### PR TITLE
Fix: failed import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   root: true,
-  extends: ["@lab/eslint-config/index.js"],
-  parser: "@typescript-eslint/parser",
+  extends: ['@binz/eslint/index.js'],
+  parser: '@typescript-eslint/parser',
 };

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Visor
 
-Full-coverage `<head>` gear for Astro apps.
+Full-coverage `<head>` gear for your Astro app.
 
 Visor automatically generates the necessary HTML tags for global metadata, including:
 
@@ -127,4 +127,4 @@ Contributions are welcome! If you find any issues or have suggestions for improv
 This Astro Head component is open source and available under the MIT License.
 
 ## Credits
-Visor builds on [Favicon Generation with Astro](https://kremalicious.com/favicon-generation-with-astro/)  by [Matthias Kretschmann](https://matthiaskretschmann.com/)
+Visor builds on [Favicon Generation with Astro](https://kremalicious.com/favicon-generation-with-astro/) by [Matthias Kretschmann](https://matthiaskretschmann.com/)

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,2 @@
+// @ts-ignore Head.astro is untyped unless loaded by language tools
+export { default as Visor, type Author, type TwitterHandle } from './src/components/Head.astro';

--- a/package.json
+++ b/package.json
@@ -1,18 +1,13 @@
 {
-  "name": "visor",
-  "version": "0.1.0",
-  "description": "Full-coverage `<head>` gear for Astro apps.",
-  "type": "module",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    },
-    "./components": "./components/index.ts"
-  },
+  "name": "@binz/visor",
+  "version": "0.1.0-beta.0",
+  "description": "Full-coverage `<head>` gear for your Astro app.",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
+    "build": "astro build",
     "lint": "eslint",
     "format": "format"
   },
@@ -22,7 +17,7 @@
     "web-vitals": "^3.5.2"
   },
   "devDependencies": {
-    "@lab/eslint-config": "workspace:*",
-    "@lab/typescript-config": "workspace:*"
+    "@binz/eslint": "*",
+    "@binz/tsconfig": "*"
   }
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,0 @@
-// @ts-ignore Head.astro is untyped unless loaded by language tools
-export {
-  default as Head,
-  type Author,
-  type TwitterHandle,
-} from './Head.astro';

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="../.astro/types.d.ts" />
+/// <reference types="astro/client" />
+declare module '*.astro';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,0 @@
-export * from './components/Head.astro';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,12 @@
 {
-  "extends": [
-    "@lab/typescript-config/base.json",
-    "astro/tsconfigs/strict"
-  ],
+  "extends": ["@binz/tsconfig/base.json", "astro/tsconfigs/strict"],
   "compilerOptions": {
     "lib": ["ES2015"],
     "jsx": "react-jsx",
     "outDir": "./dist",
     "types": ["node"]
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src", "index.ts"],
+  "exclude": ["node_modules", "dist"],
+  "moduleResolution": "node"
 }


### PR DESCRIPTION
**Package as yet unpublised**

Fixes an issue building Visor as a git submodule.

Unknown conflict, assumed infinite loop, spawned multiple processes and crashed apps - likely caused by turbo build

This will be a breaking change for remote installs as I've added a workspace package as a dependency.

This will remain a WIP with conflicts resolved on branch.